### PR TITLE
Improve markdown generator HTML escaping

### DIFF
--- a/markdown_generator/publications.py
+++ b/markdown_generator/publications.py
@@ -52,7 +52,9 @@ html_escape_table = {
 
 def html_escape(text):
     """Produce entities within text."""
-    return "".join(html_escape_table.get(c,c) for c in text)
+    if isinstance(text, str):
+        return "".join(html_escape_table.get(c, c) for c in text)
+    return ""
 
 
 # ## Creating the markdown files

--- a/markdown_generator/pubsFromBib.py
+++ b/markdown_generator/pubsFromBib.py
@@ -51,7 +51,9 @@ html_escape_table = {
 
 def html_escape(text):
     """Produce entities within text."""
-    return "".join(html_escape_table.get(c,c) for c in text)
+    if isinstance(text, str):
+        return "".join(html_escape_table.get(c, c) for c in text)
+    return ""
 
 
 for pubsource in publist:

--- a/markdown_generator/talks.py
+++ b/markdown_generator/talks.py
@@ -50,10 +50,9 @@ html_escape_table = {
     }
 
 def html_escape(text):
-    if type(text) is str:
-        return "".join(html_escape_table.get(c,c) for c in text)
-    else:
-        return "False"
+    if isinstance(text, str):
+        return "".join(html_escape_table.get(c, c) for c in text)
+    return ""
 
 
 # ## Creating the markdown files


### PR DESCRIPTION
## Summary
- Handle non-string inputs in markdown generation scripts `talks.py`, `pubsFromBib.py`, and `publications.py`

## Testing
- `npm run build:js`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `python markdown_generator/talks.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python markdown_generator/publications.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b7588056b4832ca57b411889f21f81